### PR TITLE
Fix audio visualizer initialization and guard text panel dragging

### DIFF
--- a/src/audio-manager.js
+++ b/src/audio-manager.js
@@ -3,18 +3,24 @@ export default class AudioManager {
         this.app = app;
         this.audioContext = null;
         this.analyser = null;
+        this.animationFrameId = null;
         this.audioVisualizer = document.getElementById('audioVisualizer');
     }
     
     setupAudioVisualization(mediaStream) {
-        if (!mediaStream || !this.audioContext) {
+        // Only initialize when we actually have a media stream and the
+        // audio context hasn't been created yet. The previous implementation
+        // used a logical OR which attempted to initialize even when the
+        // media stream was missing, leading to runtime errors when trying to
+        // create a MediaStreamSource with `null`.
+        if (mediaStream && !this.audioContext) {
             try {
                 this.audioContext = new (window.AudioContext || window.webkitAudioContext)();
                 const source = this.audioContext.createMediaStreamSource(mediaStream);
                 this.analyser = this.audioContext.createAnalyser();
                 this.analyser.fftSize = 256;
                 source.connect(this.analyser);
-                
+
                 this.drawAudioVisualization();
                 this.audioVisualizer.style.display = 'block';
             } catch (error) {
@@ -25,59 +31,77 @@ export default class AudioManager {
     
     drawAudioVisualization() {
         if (!this.analyser) return;
-        
+
+        // Cancel any existing loop before starting a new one to avoid
+        // multiple animation frames running in parallel.
+        if (this.animationFrameId) {
+            cancelAnimationFrame(this.animationFrameId);
+            this.animationFrameId = null;
+        }
+
         const canvas = this.audioVisualizer;
         const ctx = canvas.getContext('2d');
         const bufferLength = this.analyser.frequencyBinCount;
         const dataArray = new Uint8Array(bufferLength);
-        
+
         canvas.width = 200;
         canvas.height = 60;
-        
+
         const draw = () => {
-            requestAnimationFrame(draw);
-            
+            if (!this.analyser) return;
+            this.animationFrameId = requestAnimationFrame(draw);
+
             this.analyser.getByteFrequencyData(dataArray);
-            
+
             ctx.fillStyle = 'rgba(0, 0, 0, 0.7)';
             ctx.fillRect(0, 0, canvas.width, canvas.height);
-            
+
             const barWidth = (canvas.width / bufferLength) * 2.5;
             let barHeight;
             let x = 0;
-            
+
             for (let i = 0; i < bufferLength; i++) {
                 barHeight = (dataArray[i] / 255) * canvas.height;
-                
+
                 const red = barHeight + 25 * (i / bufferLength);
                 const green = 250 * (i / bufferLength);
                 const blue = 50;
-                
+
                 ctx.fillStyle = `rgb(${red},${green},${blue})`;
                 ctx.fillRect(x, canvas.height - barHeight, barWidth, barHeight);
-                
+
                 x += barWidth + 1;
             }
         };
-        
+
         draw();
     }
-    
+
     toggleVisualization(enabled) {
         if (enabled) {
             this.audioVisualizer.style.display = 'block';
+            // Restart drawing if the visualizer was previously disabled
+            // but the analyser still exists.
+            if (this.analyser && !this.animationFrameId) {
+                this.drawAudioVisualization();
+            }
         } else {
             this.audioVisualizer.style.display = 'none';
+            if (this.animationFrameId) {
+                cancelAnimationFrame(this.animationFrameId);
+                this.animationFrameId = null;
+            }
         }
     }
-    
+
     cleanup() {
-        this.audioVisualizer.style.display = 'none';
-        
+        this.toggleVisualization(false);
+
         if (this.audioContext) {
             this.audioContext.close();
             this.audioContext = null;
         }
+        this.analyser = null;
     }
 }
 

--- a/src/text-display-manager.js
+++ b/src/text-display-manager.js
@@ -152,11 +152,14 @@ if (key === 't' && !(e.target && e.target.matches && e.target.matches('input, te
                     e.preventDefault();
                 }
             });
-        } catch (error) {}
+    } catch (error) {}
     }
 
     setupDragging() {
+        if (!this.textPanel) return;
+
         const header = this.textPanel.querySelector('.text-panel-header');
+        if (!header) return;
         let isDragging = false;
         let startX, startY, initialX, initialY;
         header.addEventListener('mousedown', (e) => {


### PR DESCRIPTION
## Summary
- Prevent audio visualizer from initializing without a valid media stream
- Guard text panel dragging setup when panel or header elements are missing

## Testing
- `npm test` *(fails: Could not read package.json: ENOENT: no such file or directory, open '/workspace/01-streaming-studio/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68a36ff6aae08329a723f09027e6642b