### PR TITLE
Keep action buttons visible when panels collapse

### DIFF
--- a/css/popup-display.css
+++ b/css/popup-display.css
@@ -26,7 +26,7 @@
 }
 
 .text-display-panel.collapsed {
-    height: 60px;
+    height: auto;
     overflow: hidden;
 }
 
@@ -95,9 +95,17 @@
     overflow-y: auto;
 }
 
-.text-display-panel.collapsed .text-panel-content,
-.text-display-panel.collapsed .text-panel-actions {
+.text-display-panel.collapsed .text-panel-header,
+.text-display-panel.collapsed .text-panel-content {
     display: none;
+}
+
+.text-panel-actions #textPanelExpand {
+    display: none;
+}
+
+.text-display-panel.collapsed .text-panel-actions #textPanelExpand {
+    display: inline-block;
 }
 
 .text-section {
@@ -336,7 +344,7 @@
 }
 
 .image-display-panel.collapsed {
-    height: 60px;
+    height: auto;
     overflow: hidden;
 }
 
@@ -405,9 +413,17 @@
     overflow-y: auto;
 }
 
-.image-display-panel.collapsed .image-panel-content,
-.image-display-panel.collapsed .image-panel-actions {
+.image-display-panel.collapsed .image-panel-header,
+.image-display-panel.collapsed .image-panel-content {
     display: none;
+}
+
+.image-panel-actions #imagePanelExpand {
+    display: none;
+}
+
+.image-display-panel.collapsed .image-panel-actions #imagePanelExpand {
+    display: inline-block;
 }
 
 .image-section {
@@ -771,7 +787,7 @@
 }
 
 .voice-recorder-panel.collapsed {
-    height: 60px;
+    height: auto;
     overflow: hidden;
 }
 
@@ -840,9 +856,17 @@
     overflow-y: auto;
 }
 
-.voice-recorder-panel.collapsed .voice-panel-content,
-.voice-recorder-panel.collapsed .voice-panel-actions {
+.voice-recorder-panel.collapsed .voice-panel-header,
+.voice-recorder-panel.collapsed .voice-panel-content {
     display: none;
+}
+
+.voice-panel-actions #voicePanelExpand {
+    display: none;
+}
+
+.voice-recorder-panel.collapsed .voice-panel-actions #voicePanelExpand {
+    display: inline-block;
 }
 
 .voice-section {
@@ -1822,7 +1846,7 @@
 }
 
 .smart-redactor-panel.collapsed {
-    height: 60px;
+    height: auto;
     overflow: hidden;
 }
 
@@ -1891,9 +1915,17 @@
     overflow-y: auto;
 }
 
-.smart-redactor-panel.collapsed .smart-redactor-content,
-.smart-redactor-panel.collapsed .smart-redactor-actions {
+.smart-redactor-panel.collapsed .smart-redactor-header,
+.smart-redactor-panel.collapsed .smart-redactor-content {
     display: none;
+}
+
+.smart-redactor-actions #redactorPanelExpand {
+    display: none;
+}
+
+.smart-redactor-panel.collapsed .smart-redactor-actions #redactorPanelExpand {
+    display: inline-block;
 }
 
 .redactor-section {

--- a/index.html
+++ b/index.html
@@ -613,6 +613,7 @@
                 <button class="text-action-btn" id="previewTextBtn">👁 Preview</button>
                 <button class="text-action-btn" id="saveTextBtn">💾 Save</button>
                 <button class="text-action-btn" id="loadTextBtn">📁 Load</button>
+                <button class="text-action-btn" id="textPanelExpand" title="Expand">+</button>
             </div>
         </div>
 
@@ -864,6 +865,7 @@
                 <button class="image-action-btn" id="saveImageBtn">💾 Save</button>
                 <button class="image-action-btn" id="loadImageBtn">📁 Load</button>
                 <button class="image-action-btn danger" id="removeImageBtn">🗑 Remove</button>
+                <button class="image-action-btn" id="imagePanelExpand" title="Expand">+</button>
             </div>
         </div>
 
@@ -994,6 +996,7 @@
                 <button class="voice-action-btn primary" id="voiceSaveToActiveBtn">💾 Save to Active</button>
                 <button class="voice-action-btn secondary" id="voiceExportBtn">📤 Export Audio</button>
                 <button class="voice-action-btn" id="voiceSettingsBtn">⚙️ Settings</button>
+                <button class="voice-action-btn" id="voicePanelExpand" title="Expand">+</button>
             </div>
         </div>
           <!-- Smart Redactor Control Panel -->
@@ -1079,6 +1082,7 @@
                 <button class="redactor-action-btn secondary" id="saveRedactorBtn">💾 Save Content</button>
                 <button class="redactor-action-btn" id="loadRedactorBtn">📁 Load Content</button>
                 <button class="redactor-action-btn danger" id="removeContentBtn">🗑 Remove All</button>
+                <button class="redactor-action-btn" id="redactorPanelExpand" title="Expand">+</button>
             </div>
         </div>
 

--- a/src/image-display-manager.js
+++ b/src/image-display-manager.js
@@ -29,6 +29,7 @@ export default class ImageDisplayManager {
         if (this.imagePanel) this.imagePanel.classList.add('ai-scope');
         this.imagePanelCollapse = document.getElementById('imagePanelCollapse');
         this.imagePanelClose = document.getElementById('imagePanelClose');
+        this.imagePanelExpand = document.getElementById('imagePanelExpand');
         this.preserveAspectRatio = document.getElementById('preserveAspectRatio');
         this.imageFileInput = document.getElementById('imageFileInput');
         this.imageFileBrowse = document.getElementById('imageFileBrowse');
@@ -105,6 +106,9 @@ export default class ImageDisplayManager {
     bindEvents() {
         this.imageBtn.addEventListener('click', () => this.togglePanel());
         this.imagePanelCollapse.addEventListener('click', () => this.toggleCollapse());
+        if (this.imagePanelExpand) {
+            this.imagePanelExpand.addEventListener('click', () => this.toggleCollapse());
+        }
         this.imagePanelClose.addEventListener('click', () => this.hidePanel());
         this.imageFileBrowse.addEventListener('click', () => this.imageFileInput.click());
         this.imageFileInput.addEventListener('change', (e) => this.handleFileSelection(e));

--- a/src/smartRedactor.js
+++ b/src/smartRedactor.js
@@ -40,6 +40,7 @@ export default class SmartRedactorManager {
         this.redactorPanel = document.getElementById('smartRedactorPanel');
         this.redactorPanelCollapse = document.getElementById('redactorPanelCollapse');
         this.redactorPanelClose = document.getElementById('redactorPanelClose');
+        this.redactorPanelExpand = document.getElementById('redactorPanelExpand');
         
         // Analysis controls
         this.analyzeContentBtn = document.getElementById('analyzeContentBtn');
@@ -106,6 +107,9 @@ export default class SmartRedactorManager {
     bindEvents() {
         this.smartRedactorBtn.addEventListener('click', () => this.togglePanel());
         this.redactorPanelCollapse.addEventListener('click', () => this.toggleCollapse());
+        if (this.redactorPanelExpand) {
+            this.redactorPanelExpand.addEventListener('click', () => this.toggleCollapse());
+        }
         this.redactorPanelClose.addEventListener('click', () => this.hidePanel());
         
         // Analysis events

--- a/src/text-display-manager.js
+++ b/src/text-display-manager.js
@@ -23,6 +23,7 @@ export default class TextDisplayManager {
         if (this.textPanel) this.textPanel.classList.add('ai-scope');
         this.textPanelCollapse = document.getElementById('textPanelCollapse');
         this.textPanelClose = document.getElementById('textPanelClose');
+        this.textPanelExpand = document.getElementById('textPanelExpand');
         this.textContent = document.getElementById('textContent');
         this.textPosition = document.getElementById('textPosition');
         this.textFontSize = document.getElementById('textFontSize');
@@ -73,6 +74,9 @@ export default class TextDisplayManager {
             this.textBtn.addEventListener('click', () => this.togglePanel());
             if (this.textPanelCollapse) {
                 this.textPanelCollapse.addEventListener('click', () => this.toggleCollapse());
+            }
+            if (this.textPanelExpand) {
+                this.textPanelExpand.addEventListener('click', () => this.toggleCollapse());
             }
             if (this.textPanelClose) {
                 this.textPanelClose.addEventListener('click', () => this.hidePanel());

--- a/src/voice-recorder-manager.js
+++ b/src/voice-recorder-manager.js
@@ -32,6 +32,7 @@ export default class VoiceRecorderManager {
         this.voicePanel = document.getElementById('voiceRecorderPanel');
         this.voicePanelCollapse = document.getElementById('voicePanelCollapse');
         this.voicePanelClose = document.getElementById('voicePanelClose');
+        this.voicePanelExpand = document.getElementById('voicePanelExpand');
         
         // Recording controls
         this.voiceRecordBtn = document.getElementById('voiceRecordBtn');
@@ -125,6 +126,9 @@ normalizeForCloning = async (inputBlob) => {
             
             if (this.voicePanelCollapse) {
                 this.voicePanelCollapse.addEventListener('click', () => this.toggleCollapse());
+            }
+            if (this.voicePanelExpand) {
+                this.voicePanelExpand.addEventListener('click', () => this.toggleCollapse());
             }
             if (this.voicePanelClose) {
                 this.voicePanelClose.addEventListener('click', () => this.hidePanel());


### PR DESCRIPTION
## Summary
- Show panel action buttons while collapsed
- Hide headers when collapsed and provide expand buttons
- Wire up expand controls for text, image, voice, and redactor panels

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a625fa32208329922d94517ef780a4